### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/skel-db/redis/docker-compose.yml
+++ b/skel-db/redis/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   redis:
-    image: 'bitnami/redis:6.2.14'
+    image: 'soldevelo/redis:6.2.16'
     restart: always    
     ports:
       - 16379:6379


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/redis:6.2.14` → [`soldevelo/redis:6.2.16`](https://hub.docker.com/r/soldevelo/redis)